### PR TITLE
Close db conn when tx related error happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2022-05-19
+### Changed
+* Prevent connection from leaking when any tx associated resource error occurs.
+
 ## [1.4.0] - 2021-05-27
 ### Changed
 * Moved from JDK 8 to JDK 11.

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
 1. Move tests to docker-compose based databases.
 2. Upgrade test dependencies.
 3. Get rid of JMS. We don't need it in Wise.
+4. Find a better way to check that connections closing properly, maybe on db level once move to docker compose.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.4.0
+version=1.5.0

--- a/src/test/java/com/transferwise/common/gaffer/test/complextest1/ComplexTest.java
+++ b/src/test/java/com/transferwise/common/gaffer/test/complextest1/ComplexTest.java
@@ -1,5 +1,6 @@
 package com.transferwise.common.gaffer.test.complextest1;
 
+import com.transferwise.common.gaffer.jdbc.DataSourceImpl;
 import com.transferwise.common.gaffer.test.complextest1.app.ClientsService;
 import com.transferwise.common.gaffer.test.complextest1.app.Config;
 import com.transferwise.common.gaffer.test.complextest1.app.DatabasesManager;
@@ -207,6 +208,26 @@ public class ComplexTest {
   }
 
   @Test
+  public void testConnReleasedAfterTxRollback() {
+    setUp();
+    try {
+      getConfig().setFailPasswordCreation(true);
+      Stat stat = new Stat("testConnReleasedAfterTxRollback");
+      try {
+        getClientsService().deleteClient(CLIENT_NAME);
+      } finally {
+        log.info("{}", stat);
+      }
+      Assert.fail("Test has invalid logic, recheck it!");
+    } catch (Exception e) {
+      log.debug(e.getMessage(), e);
+    }
+
+    Assert.assertEquals(1, getAccountDataSource().getAllConnectionGetsCount());
+    Assert.assertEquals(1, getAccountDataSource().getClosedConnectionsCount());
+  }
+
+  @Test
   public void testJms() {
     setUpJms = true;
     setUp();
@@ -241,6 +262,10 @@ public class ComplexTest {
 
   protected ClientsService getClientsService() {
     return (ClientsService) appCtxt.getBean("clientsService");
+  }
+
+  DataSourceImpl getAccountDataSource() {
+    return ((DataSourceImpl) appCtxt.getBean("accountsDataSource"));
   }
 
   protected static class Stat {

--- a/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientNotFoundException.java
+++ b/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientNotFoundException.java
@@ -1,0 +1,8 @@
+package com.transferwise.common.gaffer.test.complextest1.app;
+
+public class ClientNotFoundException extends RuntimeException {
+
+  public ClientNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientsDao.java
+++ b/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientsDao.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 import org.hibernate.SessionFactory;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Repository;
@@ -43,6 +44,27 @@ public class ClientsDao {
       if (client == null || !client.getName().equals(name)) {
         throw new IllegalStateException("Hibernate can not find client from the current transaction. Client is '" + client + "'.");
       }
+    }
+  }
+
+  @Transactional
+  public void deleteClient(String name) {
+    try {
+      jdbcTemplate.update("delte from clients where name = (?)", name);
+    } catch (DataAccessException ex) {
+      throw new ClientNotFoundException("Client " + name + " not found ");
+    }
+  }
+
+  @Transactional
+  public void deleteAccount(String referenceNumber) {
+    try (Connection con = DataSourceUtils.getConnection(accountsDataSource);
+        PreparedStatement stmt = con.prepareStatement("delete from accounts where referenceNumber = ?")) {
+      stmt.setString(1, referenceNumber);
+      stmt.execute();
+    } catch (Exception e) {
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientsService.java
+++ b/src/test/java/com/transferwise/common/gaffer/test/complextest1/app/ClientsService.java
@@ -1,11 +1,15 @@
 package com.transferwise.common.gaffer.test.complextest1.app;
 
 import javax.annotation.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service("clientsService")
 public class ClientsService {
+
+  protected static final Logger log = LoggerFactory.getLogger(ClientsService.class);
 
   @Resource(name = "clientsDAO")
   private ClientsDao clientsDao;
@@ -32,5 +36,15 @@ public class ClientsService {
     clientsDao.createAccount(accountId, clientId, "666");
 
     usersService.createUser(clientId, "bemmimehed@tallinn.ee");
+  }
+
+  @Transactional
+  public void deleteClient(String clientName) {
+    try {
+      clientsDao.deleteClient(clientName);
+    } catch (ClientNotFoundException ex) {
+      log.error("client not found", ex);
+    }
+    clientsDao.deleteAccount("666");
   }
 }


### PR DESCRIPTION
## Context
Prevent connections from leaking when error occurs while enlisting resources associated with tx.

```
java.lang.Exception: Apparent connection leak detected
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128)
	at com.transferwise.common.spyql.SpyqlDataSource.lambda$getConnection$0(SpyqlDataSource.java:75)
	at com.transferwise.common.spyql.SpyqlDataSource.onGetConnection(SpyqlDataSource.java:92)
	at com.transferwise.common.spyql.SpyqlDataSource.getConnection(SpyqlDataSource.java:75)
	at com.transferwise.common.gaffer.jdbc.DataSourceImpl.getConnectionFromDataSource(DataSourceImpl.java:143)
	at com.transferwise.common.gaffer.jdbc.DataSourceImpl.getTransactionalConnection(DataSourceImpl.java:131)
	at com.transferwise.common.gaffer.jdbc.DataSourceImpl.getConnection0(DataSourceImpl.java:123)
	at com.transferwise.common.gaffer.jdbc.DataSourceImpl.getConnection(DataSourceImpl.java:97)
	at com.transferwise.common.jdbc.wrappers.DataSourceWrapper.getConnection(DataSourceWrapper.java:20)
	at com.transferwise.common.jdbc.wrappers.TwJdbcDataSource.lambda$getConnection$0(TwJdbcDataSource.java:28)
	at com.transferwise.common.jdbc.wrappers.TwJdbcDataSource.getConnection(TwJdbcDataSource.java:39)
	at com.transferwise.common.jdbc.wrappers.TwJdbcDataSource.getConnection(TwJdbcDataSource.java:28)
	at org.jooq.impl.DataSourceConnectionProvider.acquire(DataSourceConnectionProvider.java:83)
	at org.jooq.impl.DefaultExecuteContext.connection(DefaultExecuteContext.java:724)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:318)
	at org.jooq.impl.AbstractResultQuery.fetch(AbstractResultQuery.java:323)
	at org.jooq.impl.AbstractResultQuery.fetchInto(AbstractResultQuery.java:1440)
	at org.jooq.impl.SelectImpl.fetchInto(SelectImpl.java:3741)
```

With closer look, the connection was not put back, because `serviceRegistry.getTransactionManager().getTransactionImpl().enlistResource(xaResource)` failed due to in this particular case the transaction having already been marked as rolling back.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
