### PR TITLE
Fixes creating of git tag for master build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Verify matrix jobs succeeded
         if: ${{ needs.matrix_build.result != 'success' }}
         run: exit 1
+      - name: Checkout repository
+        uses: actions/checkout@v3
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon


### PR DESCRIPTION
## Context

Master builds are failing due to 

```
2: ssh-keyscan: not found
Error: Process completed with exit code 127.
```
Fixes creating of git tag for master build.

We don't need that old keyscan trick with gradle's git plugin.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
