### PR TITLE
Fixes creating of git tag for master build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Verify matrix jobs succeeded
         if: ${{ needs.matrix_build.result != 'success' }}
         run: exit 1
+      - name: "Install packages"
+        run: |
+          apt-get update && apt-get install -y git unzip
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: "Tag release"


### PR DESCRIPTION
## Context

Master builds are failing due to 

```
2: ssh-keyscan: not found
Error: Process completed with exit code 127.
```
Fixes creating of git tag for master build.

We don't need that old keyscan trick with gradle's git plugin.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 