### PR TITLE
Fixing nexus publishing for oss-publish framework.

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -73,6 +73,10 @@ compileJava {
 
     options.fork = true
     options.forkOptions.jvmArgs << '-Xmx256m'
+
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 compileTestJava {

--- a/build.gradle
+++ b/build.gradle
@@ -34,3 +34,12 @@ task tagRelease {
         }
     }
 }
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv("SONATYPE_USER")
+            password = System.getenv("SONATYPE_PASSWORD")
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ apply from: 'build.common.gradle'
 
 idea.project {
     vcs = 'Git'
-    languageLevel = JavaVersion.VERSION_11
-    targetBytecodeVersion = JavaVersion.VERSION_11
+    languageLevel = JavaVersion.VERSION_17
+    targetBytecodeVersion = JavaVersion.VERSION_17
 }
 
 task tagRelease {

--- a/tw-gaffer-jta-starter/src/main/java/com/transferwise/common/gaffer/starter/GafferJtaSpringIntegrationDataSourceAdapter.java
+++ b/tw-gaffer-jta-starter/src/main/java/com/transferwise/common/gaffer/starter/GafferJtaSpringIntegrationDataSourceAdapter.java
@@ -1,7 +1,6 @@
 package com.transferwise.common.gaffer.starter;
 
 import com.transferwise.common.gaffer.jdbc.DataSourceWrapper;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.sql.Connection;
 import java.sql.SQLException;
 import org.springframework.transaction.support.TransactionSynchronizationManager;


### PR DESCRIPTION
## Context

Fixing nexus publishing for oss-publish framework.

Currently it fails, because of:

```
* Exception is:
org.gradle.execution.TaskSelectionException: Task 'initializeSonatypeStagingRepository' not found in root project 'tw-gaffer-jta' and its subprojects.
```

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
