### PR TITLE
Fixing group for nexus publishing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ task tagRelease {
     }
 }
 
+group = 'com.transferwise.common'
+
 nexusPublishing {
     repositories {
         sonatype {


### PR DESCRIPTION
## Context

Fixing group for nexus publishing.

Otherwise oss-publish gives an error about missing group.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
