### PR TITLE
Fix documentation to suggest correct name of bean created by lib

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,6 @@ dependencies {
 
 Add the `com.transferwise.common:tw-gaffer-jta-starter` dependency.
 
-It will create the necessary transaction manager objects and wrap all data sources exposed as beans with Gaffer's `DataSourceImpl`.
+It will create the necessary transaction manager objects and wrap all data sources exposed as beans with Gaffer's `GafferJtaDataSource`.
 
 You can configure each datasource via `GafferJtaProperties` class.


### PR DESCRIPTION
## Context

The name of a bean created by the starter lib has changed since the last version of the library, updating the documentation to suggest the correct name of the bean being created.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
