### PR TITLE
Documentation improvement, explaining how to use starter lib

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,8 +18,7 @@ dependencies {
 
 ## Configuration in Spring Boot Service
 
-Add the `com.transferwise.common:tw-gaffer-jta-starter` dependency.
-
-It will create the necessary transaction manager objects and wrap all data sources exposed as beans with Gaffer's `GafferJtaDataSource`.
-
-You can configure each datasource via `GafferJtaProperties` class.
+1. Add the `com.transferwise.common:tw-gaffer-jta-starter` dependency.
+2. Expose all your HikariCP datasource's as beans.
+3. `tw-gaffer-jta-starter` Will then automatically wrap all data sources and expose them as beans with Gaffer's `GafferJtaDataSource`.
+4. If you need to configure the Gaffer datasource's, you can do so using the `GafferJtaProperties` class, creating a bean of that type.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,4 +21,16 @@ dependencies {
 1. Add the `com.transferwise.common:tw-gaffer-jta-starter` dependency.
 2. Expose all your HikariCP datasource's as beans.
 3. `tw-gaffer-jta-starter` Will then automatically wrap all data sources and expose them as beans with Gaffer's `GafferJtaDataSource`.
-4. If you need to configure the Gaffer datasource's, you can do so using the `GafferJtaProperties` class, creating a bean of that type.
+4. If you need to configure the Gaffer datasource's, you can do so using the `GafferJtaProperties` class*.
+
+\* You can do this in two ways:
+1. Create a configuration entry in your `application.yml`, which will then cause the bean to be automatically created. For example:
+```yaml
+tw-gaffer-jta:
+  core:
+    databases:
+      mydb:
+        commitOrder: 15
+        connectionValidationInterval: 31s
+```
+2. Create the `GafferJtaProperties` bean yourself.


### PR DESCRIPTION
## Context

Previous documentation did not properly explain how to use the new gaffer-jta-starter library, this PR adds missing documentation.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
