### PR TITLE
[APPENG-582] Add support for Spring Boot 3.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.0.6
+          - 3.1.2
+          - 3.0.7
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2023-08-01
+
+### Added
+
+* Support for Spring Boot 3.1
+
+### Bumped
+
+* Build against Spring Boot 3.0.6 --> 3.0.7
+
 ## [3.0.0] - 2023-05-06
 
 ### Changed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "3.0.6"
+    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "3.0.7"
 
     libraries = [
             // explicit versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0
+version=3.0.1


### PR DESCRIPTION
## Context

Spring Boot 3.1.2 is out now so adding support for that version in this library.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
