### PR TITLE
Create BeanPostProcessor beans in static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2024-04-05
+
+### Changed
+
+* Use static methods to create BeanPostProcessors.
+
 ## [3.0.2] - 2024-02-29
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.2
+version=3.0.3

--- a/tw-gaffer-jta-starter/src/main/java/com/transferwise/common/gaffer/starter/GafferJtaConfiguration.java
+++ b/tw-gaffer-jta-starter/src/main/java/com/transferwise/common/gaffer/starter/GafferJtaConfiguration.java
@@ -49,7 +49,7 @@ public class GafferJtaConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  public GafferJtaDataSourceBeanProcessor gafferJtaDataSourceBeanProcessor() {
+  public static GafferJtaDataSourceBeanProcessor gafferJtaDataSourceBeanProcessor() {
     return new GafferJtaDataSourceBeanProcessor();
   }
 


### PR DESCRIPTION
## Context

Create BeanPostProcessor beans in static methods to avoid the autoconfiguration classes to be processed in bean post-processing phase and logging a warning.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
