### PR TITLE
APPENG-849: Add support for Spring Boot 3.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,8 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.2.2
-          - 3.1.2
-          - 3.0.7
+          - 3.3.1
+          - 3.2.7
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-07-18
+
+### Changed
+* Run tests against Spring Boot 3.3.
+* Baseline moved to Spring Boot 3.2. Library is now built and published against Spring Boot 3.2.
+
 ## [3.0.3] - 2024-04-05
 
 ### Changed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,5 +1,5 @@
 ext {
-    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "3.0.7"
+    springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "3.2.7"
 
     libraries = [
             // explicit versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.3
+version=3.1.0


### PR DESCRIPTION
## Context

Add Spring Boot 3.3 as part of the matrix test suite.
Update baseline to Spring Boot 3.2 so that the library is built and published using Spring Boot 3.2.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
