### PR TITLE
Disabling abandoned transactions tracker.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,40 +24,40 @@ jobs:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-home-cache-cleanup: true
           # Comment out when you are upgrading gradle in a branch and doing tons of commits you would need to test.
           # cache-read-only: false
       - name: "Assemble jar"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: assemble --console=plain --info --stacktrace --parallel
       - name: "Compile tests"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: compileTest --console=plain --info --stacktrace --parallel
       - name: "Run checks"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: check -x test --console=plain --stacktrace
       - name: "Run tests"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: -Dspring.profiles.include=continuous-integration test --console=plain --info --stacktrace
       - name: "Test if publishing works"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: publishToMavenLocal --console=plain --info --stacktrace
       - name: "Publish Test Report"
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v5
         if: always()
         with:
           check_name: Test Report-(${{ matrix.spring_boot_version }})
@@ -81,7 +81,7 @@ jobs:
           tar -zcvf all-test-reports-${{ matrix.spring_boot_version }}.tar.gz **/build/reports
         if: always()
       - name: "Store test results"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: all-test-reports-${{ matrix.spring_boot_version }}
@@ -101,15 +101,15 @@ jobs:
         if: ${{ needs.matrix_build.result != 'success' }}
         run: exit 1
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-home-cache-cleanup: true
           # Comment out when you are upgrading gradle in a branch and doing tons of commits you would need to test.
           # cache-read-only: false
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: tagRelease --console=plain --info --stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0]
+
+* Disabling abandoned transactions tracker.
+
 ## [3.1.1]
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.1.1
+version=3.2.0

--- a/tw-gaffer-jta/src/main/java/com/transferwise/common/gaffer/TransactionImpl.java
+++ b/tw-gaffer-jta/src/main/java/com/transferwise/common/gaffer/TransactionImpl.java
@@ -50,7 +50,7 @@ public class TransactionImpl implements Transaction {
     exceptionThrower = new ExceptionThrower(serviceRegistry.getConfiguration().isLogExceptions());
 
     abandonedTransactionsTracker = new AbandonedTransactionsTracker(getTransactionManagerStatistics(), globalTransactionId, status);
-    cleaner.register(this, abandonedTransactionsTracker);
+    //cleaner.register(this, abandonedTransactionsTracker);
   }
 
   public void setSuspended(boolean suspended) {


### PR DESCRIPTION
## Context

Disabling abandoned transactions tracker.

One of our services started to run out of memory due to phantom references not being getting cleaned up.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
